### PR TITLE
Query all api keys per env

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ DATABASE_URL=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
 HTTP_PORT=8080
 ALLOWED_CORS_ORIGIN=http://localhost:3000
 DEBUG_MODE=enabled
-PRODUCTION_MODE=false
+PRODUCTION_MODE=true
 WEBHOOK_EMULATOR_URL=http://emulators:8091
 CLERK_EMULATOR_SERVER_URL=http://emulators:8090
 HTTP_ALLOWED_CORS=http://localhost:3000

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ DATABASE_URL=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
 HTTP_PORT=8080
 ALLOWED_CORS_ORIGIN=http://localhost:3000
 DEBUG_MODE=enabled
-PRODUCTION_MODE=true
+PRODUCTION_MODE=false
 WEBHOOK_EMULATOR_URL=http://emulators:8091
 CLERK_EMULATOR_SERVER_URL=http://emulators:8090
 HTTP_ALLOWED_CORS=http://localhost:3000

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,9 @@
 version: 3
 
 dotenv:
+  - ./.env.secrets
   - ./.env.local
   - ./.env
-  - ./.env.secrets
 
 tasks:
   run:backend:

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -95,6 +95,28 @@ paths:
         default:
           $ref: '#/components/responses/DefaultError'
   /api-keys:
+    get:
+      tags:
+        - ApiKeys
+      operationId: getAllApiKeys
+      summary: Get all api keys
+      security:
+        - BearerAuth: [ ]
+      parameters:
+        - name: environment_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAllApiKeysPayload'
+        default:
+          $ref: '#/components/responses/DefaultError'
     post:
       tags:
         - ApiKeys
@@ -374,6 +396,30 @@ components:
         expires_at:
           type: string
           format: date-time
+    ApiKey:
+      required: [name, masked_secret_key, organization_id, environment_id, created_at]
+      properties:
+        name:
+          type: string
+        organization_id:
+          type: string
+        environment_id:
+          type: string
+        masked_secret_key:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    GetAllApiKeysPayload:
+      required: [ data ]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKey'
     # Environments
     Environment:
       required: [id, name, organization_id, name, type, created_at]

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -169,8 +169,6 @@ func run(logger *logs.Logger) error {
 
 	var webhookVerifier http.LoginProviderWebhookVerifier
 	if config.ProductionMode {
-
-		logger.Info("### clerk wh secret", "key", config.ClerkWebhookSecret)
 		webhookVerifier, err = svix.NewWebhook(config.ClerkWebhookSecret)
 		if err != nil {
 			return fmt.Errorf("unable to create a webhook verifier: %v", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       APP_NAME: backend
     env_file:
       - ./.env
+      - ./.env.secrets
     ports:
       - "8080:8080"
     volumes:
@@ -31,7 +32,7 @@ services:
     stop_grace_period: 1s
     restart: always
     env_file:
-      - ./.env
+      ./.env
     environment:
       APP_NAME: emulators
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       APP_NAME: backend
     env_file:
       - ./.env
-      - ./.env.secrets
     ports:
       - "8080:8080"
     volumes:

--- a/internal/adapters/psql/api_key_test.go
+++ b/internal/adapters/psql/api_key_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/subscribeddotdev/subscribed-backend/internal/adapters/models"
 	"github.com/subscribeddotdev/subscribed-backend/internal/domain"
 	"github.com/subscribeddotdev/subscribed-backend/tests/fixture"
 )
@@ -28,4 +29,34 @@ func TestApiKeyRepository_Insert(t *testing.T) {
 	t.Run("error_api_key_already_exists", func(t *testing.T) {
 		assert.ErrorIs(t, apiKeyRepo.Insert(ctx, apiKey), domain.ErrApiKeyExists)
 	})
+}
+
+func TestApiKeyRepository_FindAll(t *testing.T) {
+	ff := fixture.NewFactory(t, ctx, db)
+	org := ff.NewOrganization().Save()
+	env1 := ff.NewEnvironment().WithOrganizationID(org.ID).Save()
+	env2 := ff.NewEnvironment().WithOrganizationID(org.ID).Save()
+
+	fixtureApiKeys := make(map[string]models.APIKey)
+	for i := 0; i < 10; i++ {
+		var ak models.APIKey
+		if i%2 == 0 {
+			ak = ff.NewApiKey().WithEnvironmentID(env1.ID).WithOrgID(org.ID).Save()
+		} else {
+			ak = ff.NewApiKey().WithEnvironmentID(env2.ID).WithOrgID(org.ID).Save()
+		}
+		fixtureApiKeys[ak.SecretKey] = ak
+	}
+
+	apiKeys, err := apiKeyRepo.FindAll(ctx, org.ID, domain.EnvironmentID(env1.ID))
+	require.NoError(t, err)
+	require.NotEmpty(t, apiKeys)
+
+	for _, apiKey := range apiKeys {
+		_, exists := fixtureApiKeys[apiKey.SecretKey().FullKey()]
+		require.True(t, exists)
+
+		require.Equal(t, org.ID, apiKey.OrgID(), "api key must belong to the target organisation")
+		require.Equal(t, env1.ID, apiKey.EnvID().String(), "api key must belong to the target environment")
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,6 +29,7 @@ type Command struct {
 
 type Query struct {
 	Environments QueryHandler[query.Environments, []*domain.Environment]
+	AllApiKeys   QueryHandler[query.AllApiKeys, []*domain.ApiKey]
 }
 
 type App struct {

--- a/internal/app/query/all_api_keys.go
+++ b/internal/app/query/all_api_keys.go
@@ -1,0 +1,24 @@
+package query
+
+import (
+	"context"
+
+	"github.com/subscribeddotdev/subscribed-backend/internal/domain"
+)
+
+type AllApiKeys struct {
+	OrgID         string
+	EnvironmentID string
+}
+
+type allApiKeysHandler struct {
+	repo domain.ApiKeyRepository
+}
+
+func NewAllApiKeysHandler(repo domain.ApiKeyRepository) allApiKeysHandler {
+	return allApiKeysHandler{repo: repo}
+}
+
+func (h allApiKeysHandler) Execute(ctx context.Context, q AllApiKeys) ([]*domain.ApiKey, error) {
+	return h.repo.FindAll(ctx, q.OrgID, domain.EnvironmentID(q.EnvironmentID))
+}

--- a/internal/common/clerkhttp/echo_oapi_auth_middleware.go
+++ b/internal/common/clerkhttp/echo_oapi_auth_middleware.go
@@ -26,7 +26,7 @@ type EchoOapiAuthMiddleware struct {
 }
 
 func NewEchoOapiAuthMiddleware(clerkSecretKey string) *EchoOapiAuthMiddleware {
-	// clerk.SetKey(clerkSecretKey)
+	clerk.SetKey(clerkSecretKey)
 	return &EchoOapiAuthMiddleware{}
 }
 

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -43,4 +43,5 @@ type MessageRepository interface {
 type ApiKeyRepository interface {
 	Insert(ctx context.Context, apiKey *ApiKey) error
 	FindBySecretKey(ctx context.Context, sk SecretKey) (*ApiKey, error)
+	FindAll(ctx context.Context, orgID string, envID EnvironmentID) ([]*ApiKey, error)
 }

--- a/internal/ports/http/server.gen.go
+++ b/internal/ports/http/server.gen.go
@@ -37,6 +37,16 @@ type AddEndpointRequest struct {
 	Url          string    `json:"url"`
 }
 
+// ApiKey defines model for ApiKey.
+type ApiKey struct {
+	CreatedAt       time.Time  `json:"created_at"`
+	EnvironmentId   string     `json:"environment_id"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	MaskedSecretKey string     `json:"masked_secret_key"`
+	Name            string     `json:"name"`
+	OrganizationId  string     `json:"organization_id"`
+}
+
 // ClerkWebhookEmailAddress defines model for ClerkWebhookEmailAddress.
 type ClerkWebhookEmailAddress struct {
 	// EmailAddress User's email address
@@ -187,6 +197,11 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// GetAllApiKeysPayload defines model for GetAllApiKeysPayload.
+type GetAllApiKeysPayload struct {
+	Data []ApiKey `json:"data"`
+}
+
 // GetAllEnvironmentsPayload defines model for GetAllEnvironmentsPayload.
 type GetAllEnvironmentsPayload struct {
 	Data []Environment `json:"data"`
@@ -200,6 +215,11 @@ type SendMessageRequest struct {
 
 // DefaultError defines model for DefaultError.
 type DefaultError = ErrorResponse
+
+// GetAllApiKeysParams defines parameters for GetAllApiKeys.
+type GetAllApiKeysParams struct {
+	EnvironmentId string `form:"environment_id" json:"environment_id"`
+}
 
 // CreateApiKeyParams defines parameters for CreateApiKey.
 type CreateApiKeyParams struct {
@@ -233,6 +253,9 @@ type CreateAccountJSONRequestBody = CreateAccountRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Get all api keys
+	// (GET /api-keys)
+	GetAllApiKeys(ctx echo.Context, params GetAllApiKeysParams) error
 	// Create a new api key
 	// (POST /api-keys)
 	CreateApiKey(ctx echo.Context, params CreateApiKeyParams) error
@@ -262,6 +285,26 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts echo contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler ServerInterface
+}
+
+// GetAllApiKeys converts echo context to params.
+func (w *ServerInterfaceWrapper) GetAllApiKeys(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAllApiKeysParams
+	// ------------- Required query parameter "environment_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, true, "environment_id", ctx.QueryParams(), &params.EnvironmentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter environment_id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetAllApiKeys(ctx, params)
+	return err
 }
 
 // CreateApiKey converts echo context to params.
@@ -468,6 +511,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
+	router.GET(baseURL+"/api-keys", wrapper.GetAllApiKeys)
 	router.POST(baseURL+"/api-keys", wrapper.CreateApiKey)
 	router.POST(baseURL+"/applications", wrapper.CreateApplication)
 	router.POST(baseURL+"/applications/:applicationID/endpoints", wrapper.AddEndpoint)
@@ -482,38 +526,40 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RZX3PbuBH/Khi0M/HNyKKvebnRU3W2mqZ3aTq2r3lIPByIWJGISYABQNlqRt+9gz8U",
-	"SRGUaMVukzeSWOwufvvbxQL8ihNRlIID1wrPvmIJqhRcgX25ghWpcr2QUkjzngiugWvzSMoyZwnRTPDo",
-	"sxLcfFNJBgUxT3+WsMIz/KeoUR65URVZbdfeDN5utxNMQSWSlUYZnuE5SoGDZAkCI4pkIzvxNqx3c0oX",
-	"nJaCcX0NXypQ1rFSihKkZm4FHc1fsd6UgGdYacl4ircTDGvgOjafY0btDKahUEFZ/4FISTbmvZJ5QG47",
-	"wRK+VEwCxbOPVuhuO8GXOcj7D7DMhLhfFITlc0olKNV3GcxoTJrhLjp/KJCvFLJSqJaa9L1lNDCXsy8V",
-	"IEaBa7ZiINFKSKQzOK4uZ/weaKxFX+vZ3CCCmHGq1Buv07wacH/Ckx6mYvkZEm3U8irPyTIHPNOygj7G",
-	"XrJn8739jow4OiP5A9ko9KkL3Scc8KS3rjVItvJE7sdCaaKrQBD+3ZqFnBA6g2k6naBPXiXQT9i8Vbx5",
-	"D3qgtCQa0s1RK06ssaNZcg/aWTHhCepveFuDvkfQLt0sb9rR3ueuod+lBKKBXhFN+pAtmdQZJZtB5tYC",
-	"6MzRxXmK2ApxoZGCcJwSZzMmATLcsgKUJkWJzqAUSYYKludMQSI4VT8hCaUEZSjPU1QpkMgqM6BqVkBj",
-	"jXENKUhbF9qoQLcwHCpug2keqB/wqEFyksckSUTl6+/zpdaguWBl8FXFy7RKBB5M0iY4KyaVjjkpYFCz",
-	"FUFWZITCFDgFOajMDT+NQE+rh4YmQS0FSSH2lT/om5VAf1z/js4KskFLQBIoSTTQoFs5OYackRgNnFWn",
-	"WMpjxr85V6xlo+yc7VJlwINW6jytZBugx1Xqkij1ICSNgRsHAuH8kIHOoAkgyohC9TREKp2Zhfl6WmvZ",
-	"WVoKkQPh1lQmOMS8KpYgXzgrS8kKIjdxp+DETyOr19HbxI+ypTbeXu+Jtq0K5FSgM2N5LyFHO/MAy9fx",
-	"A8lz0Cf6YjQgp+FkV9ZEQ1yAJtTvcsHc9IKoFqxLkov3MKsbPpRSrFgO8fHC4iWfWmDKapmzZMRSrNw3",
-	"rEQ/iHhFEi3kiAx9EOdOdj8tjYkDmVlxRVYjAuPkvmE1VUmfr99wyoa7DSM0vAeYkdN43EqlFy1jey2l",
-	"bSF75TrIkE5j12+7bPdpBeauRxo+6Hk2jG3O9vvYAxvXwsAR2rem3vdx+5f78CLK9/C3WOzW46XvAiT3",
-	"0JbsN9gMIguPJZOgfCashCzMkzEC511GN2utyXzYTyvVCnFzpTDozEmKLca3mxJOviYYMDtpXXkMDMXw",
-	"SIoyf4rTC75mUvDC37R0PSUyydh6V5jGhaN7eBo3x22945EQMiWc/ceGLx6YXKcA8KowSy6loFViUZ9g",
-	"CmvIRWmXfXeM4rbE+KZ43/JuwKrorN7C27l/6tO9vuzay1N7FZVUSovC30slggJSVZIhotArV7oYjysF",
-	"r0KAFqAUSQMlYI5a74gsRaXdnYz15BgStVStPpTnb0DP87zFK/UvsskFocN1dNRpt83UY5uCVWzwvwFO",
-	"3zlnh2tO+1ouSKWyWcARfDqqmol39jYRkkoyvbkxC3KmXTWcVzqzMJgAZUCoOwhb8uPHc1Ky83vYNMEh",
-	"dpZx7FcgEmQ9f2nf/lZn3D8+3GJfGWxjY0cbLZnWpbsRrQ/iVyIJ7NxGTs2iKGU6q5bTRBSRqpZGYgmU",
-	"Ck1h3fpwviTJPXAaXS/mV+8W08LAYDvNExXZ8sBXor4SJm7XtBmAZ3jFZMG4mCYZ4SYz/5qaAaMc9+56",
-	"b3bKXylUq5/gnCXgs9Nj/u7t7Td6Hf3+9nLxzxu7fkNWkIV6v7oBuWYJnI7FBGumc0vA0OAapHJLvZhe",
-	"TH+2lbIETkqGZ/j19GL62nJSZzbMkSeWuxYWLjVMYtji9pbiWWfPtlMlKUDbc+rHAb5Ck6YuB5r8cI3j",
-	"4C62vXPCoPSvgm6e7R9AqPHYdjPXeGY/tP5H/OXi534yXF4v5reLK8ct+79iyPpOV9T5sdEuBBbEdgp/",
-	"vDMYqKowJ8sd/IggDg+IlAz5MkBSEwBfPZSrLlELoBER3cnilwW912V9P8i3i28YebWDvg1XA38L8H4M",
-	"oq+tt7dX2wj8/6MD0Wn9ZRpIN5O9TbJ1LHwPuRb4TfZjpNqcUkQ4qmOEtDCv4cAvdoEcEXXfKh0IeqtH",
-	"+TGDHmiyfowsN44jgnyIDsb8XR1GF/LWLmcXk0IgsG9At9tg3APg4tlCMNx0B/55v//tf5RUb0AjkucI",
-	"uig0edT67HE1DfS54e3RPWx30H7RHax3nP+ROod6/4LdvU8b/XplNfYZkNwdJIJs/rsdvswguR9g8vOy",
-	"rPbT2fU+PrgLNRX535hHGx0vNq53VWv2eP7EpnVySJeuL2+fT6ViKSe6kvAdtdbd69L/b4YMtXA7Iuza",
-	"t8qxyqaVXNfEaE59syjKRULyTCg9++Xilwu8vdv+NwAA//8K/1nRwyQAAA==",
+	"H4sIAAAAAAAC/9RZX3PbuBH/Khi0M/HNyKKvebnRU3W22qZ3aTq2r3lIPByIWJE4kwADgJLVjL57B38o",
+	"kiKof7Z7yZsgLBeL3/52sVh8xYkoSsGBa4UnX7EEVQquwA5uYEGqXM+kFNKME8E1cG1+krLMWUI0Ezz6",
+	"XQlu/lNJBgUxv/4sYYEn+E9Rozxysyqy2m79Mniz2YwwBZVIVhpleIKnKAUOkiUIjCiSjezIr2Gtm1I6",
+	"47QUjOtb+FKBsoaVUpQgNXM76Gj+ivW6BDzBSkvGU7wZYVgC17H5O2bUfsE0FCoo6/8gUpK1GVcyD8ht",
+	"RljCl4pJoHjyyQo9bEZ4WrJfYN03MJFANNCYWOMXQhbmF6ZEw6VmBeBRwGi+ZFLwwpjOaHhfTyWToE5S",
+	"WxD1CDRWkEjQ8aOztifFSQHBCSFTwtl/LSXCZu1AYzWFlu3r6u151AbO4Hudg3z8CPNMiMdZQVg+pVSC",
+	"Un3EwczGpJnusu83BfKNQlYK1VIBtNwOd77l7EsFiFHgmi0YSLQQEukMDqvLGTcoaNHXejE1jEPMGFXq",
+	"tddphoa8P+BRj7Ni/jsk2nqrynMyzwFPtKygz2Ev2Vvzg/0fGXF0QfIVWSv0uQvdZxywpLevJUi28Imi",
+	"7wulia4CTvhP6yvkhNAFjNPxCH32KoF+xmZU8WYctEBpSTSk64OrOLFmHc2SR9BuFeOeoP4mL9Sg77C8",
+	"SzfLm7a3d7lr6HftqH1DNOlDNmdSZ5SsB5lbC6ALRxdnKWILxIVGCsJ+6uahruJ7VoDSpCjRBZQiyVDB",
+	"8pwpSASn6gckoZSgDOV5iioFElllBtRuqmFcQwrS5qc2KtBNvPsOj8EwD+RneNIgOcljkiSi8ufby4XW",
+	"4HLBzOCzipdppQg8GKSNcxZMKh3XmTeo2Yogn1IPKkyBU5CDytz0aQQ6LR8amgS1FCSF2J+sQdusBPrt",
+	"9ld0UZA1mgOSQEmigQbNyskh5IzE0cBZdYqlPGb82bFiVzbKLtk2VAYsaIXOaSnbAH1cpi6JUishaQzc",
+	"GBBw58cMdAaNA1FGFKo/Q6TSmdmYz6e1lu1KcyFyINwulQkOMa+KOchXjspSsoLIddxJOPFpZPU6eof4",
+	"QbbUi7f3e+baVgVyKtCFWXknII82ZgXzt/GK5DnoM20xGpDTcLYpS6IhLkAT6k+5YGx6QVQL1inJ+XuY",
+	"1Q0fSikWLIf4cGLxkqcmmLKa5yw5YitW7hk70SsRL0iihTwiQlfi0snuhqVZYk9kVlyRxRGOcXLP2E1V",
+	"0perN5yy4WrDCA2fAWbmPB63QulV09hOSWlLyF66DjKkU9j1yy5bfVqBqauRhi/Sng3HFme7deyeg2tm",
+	"4AidW2Nv+3Hnl/vjVZTv4G+x2O7HSz8ESO6htVf/QWTPuaoPXMJDF+yWi5uWzaAxZym2GN+vSzi7DTPY",
+	"VGhaSgNTMTyRosxPMXrWtBL6lhKZZGx5YkPmnCbOQOPmGe2VJgSAV4XZcikFrRKL+ghTWEIuSrvth0MU",
+	"tynGF8X9ZoyfsCp6nZhuf69P97qZuBOnttWXVEqLwvf9EkEBqSrJEFHojUtdjMeVgjfB9hUoRdJACpii",
+	"1hiRuai068lYSw4hUUvV6kNx/nfQ0zx3ca7+Tda5IHQ4hR510fX9wkNHgdX5sDWhRe0XsqMdLEcbcwec",
+	"vnd4Dae9duc1yOay2cABF3VUNR8+2IYxJJVken1nNuSWdthOK51ZGAxHMiDU3cVt/OGnS1KyS9eMrPe8",
+	"9cjPQCTI+vu5Hf2tDvp/frzHPjnZ2srONloyrUvX9K57ATciCRQPRk5NoihlOqvm40QUkarmRmIOlApN",
+	"Ydn643JOkkfgNLqdTW/ez8aFgcEWu2cqshmKL0Td9Sfu4LZBiCd4wWTBuBgnGeEmOfw1NRNGOe618++2",
+	"yt8oVKsf4Zwl4BOEx/z9u/tnWh39+u569q87u39DVpCF+rC4A7lkCZyPxQhrpnNLwNDkEqRyW70aX41/",
+	"tMm6BE5Khif47fhq/NZyUmfWzZEnlh2kYGE1cWHT6zuKJ91sYj+VpABtr8qfPF+/VCDXDV173fEmPFzp",
+	"OniObh5G3Tefv1xdvdhTTzAvBl58PvziaGNfm4aUbq2MOs9S7Ri3+LSj89OD2Z+qCnNvddAikueIlAw9",
+	"OnQ1SQ2uuMbb5K9SqIBf2tXcgFt208hz/WJz58+Crl/MJaGSdNNNqMayTY8VP/Zz1PXtbHo/u/k/+c5Z",
+	"jgjisKodGPTfZmSCbAuQewLa69GtLH5d0Hv197eDfPtMDCOvttC34WrgbwHe90H0tTV6d7OJwL/c7vFO",
+	"6313INxMUm2CrbPCtxBrgQfq7yPUppQiwlHtI6SFGYYdP9s68giv+yJ6j9NbpeP36fRA7ft9RLkxHBHk",
+	"XbTX5+9rNzqXt065vVVN+3aCX73sCN2FvoXaA7ooNHHU+tvjau41l4a3B8+wbQvmVU+wXqPne6oc6vML",
+	"th3BNvr1zmrsMyC5u98F2fwPO32dQfI4wOSXZVltp1vX27hyrVYV+Qfug4WOFzuudlVL9nR5YtE62qdL",
+	"1239l1OpWMqJriR8Q6V1t5H+x0bIUAm3JcK2fKscq2xYyWVNjOYyPomiXCQkz4TSk5+ufrrCm4fN/wIA",
+	"AP//Ik5LIT0oAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/tests/components/api_keys_test.go
+++ b/tests/components/api_keys_test.go
@@ -39,4 +39,15 @@ func TestApiKeys_Lifecycle(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
+
+	t.Run("get_all_api_keys_by_environment", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			ff.NewApiKey().WithEnvironmentID(env.ID).WithOrgID(org.ID).Save()
+		}
+
+		resp, err := getClient(t, token).GetAllApiKeysWithResponse(ctx, &client.GetAllApiKeysParams{EnvironmentId: env.ID})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+		require.NotEmpty(t, resp.JSON200.Data)
+	})
 }


### PR DESCRIPTION
- Add endpoint `GET /api-keys?environment_id=<string>` to allow querying api keys by env;
- Add integration and component tests;