### PR TITLE
Add http endpoint to query app via `id` and `orgId`

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -73,6 +73,28 @@ paths:
                 $ref: '#/components/schemas/GetApplicationsPayload'
         default:
           $ref: '#/components/responses/DefaultError'
+  /applications/{applicationID}:
+    get:
+      tags:
+        - Applications
+      operationId: getApplicationById
+      summary: Returns an application
+      security:
+        - ApiKeyAuth: [ ]
+        - BearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/applicationId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetApplicationByIdPayload'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        default:
+          $ref: '#/components/responses/DefaultError'
   /applications/{applicationID}/endpoints:
     post:
       tags:
@@ -107,11 +129,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - name: applicationID
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/applicationId'
       requestBody:
         required: true
         content:
@@ -264,6 +282,12 @@ paths:
 
 components:
   parameters:
+    applicationId:
+        name: applicationID
+        in: path
+        required: true
+        schema:
+          type: string
     paginationParamLimit:
       name: limit
       description: The number of items per page
@@ -359,6 +383,11 @@ components:
         data:
           type: array
           items:
+            $ref: '#/components/schemas/Application'
+    GetApplicationByIdPayload:
+      required: [ data ]
+      properties:
+        data:
             $ref: '#/components/schemas/Application'
     # Messages
     SendMessageRequest:
@@ -493,6 +522,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/GenericResponse'
+    NotFoundError:
+      description: 'Item not found'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
     DefaultError:
       description: 'A generic error response'
       content:

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -132,6 +132,7 @@ func run(logger *logs.Logger) error {
 
 			// Applications
 			AllApplications: observability.NewQueryDecorator[query.AllApplications, query.Paginated[[]domain.Application]](query.NewAllApplicationsHandler(applicationRepo), logger),
+			Application:     observability.NewQueryDecorator[query.Application, *domain.Application](query.NewApplicationHandler(applicationRepo), logger),
 		},
 	}
 

--- a/internal/adapters/psql/application.go
+++ b/internal/adapters/psql/application.go
@@ -72,6 +72,14 @@ func (o ApplicationRepository) FindAll(
 	}, nil
 }
 
+func (o ApplicationRepository) FindByID(
+	ctx context.Context,
+	id domain.ApplicationID,
+	orgID iam.OrgID,
+) (*domain.Application, error) {
+	return nil, nil
+}
+
 func mapPaginationParamsToSqlOffset(pagination query.PaginationParams) int {
 	if pagination.Page() == 1 {
 		return 0

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,6 +48,7 @@ type Query struct {
 	AllEnvironments QueryHandler[query.AllEnvironments, []*domain.Environment]
 
 	// Applications
+	Application     QueryHandler[query.Application, *domain.Application]
 	AllApplications QueryHandler[query.AllApplications, query.Paginated[[]domain.Application]]
 }
 

--- a/internal/app/query/all_applications.go
+++ b/internal/app/query/all_applications.go
@@ -20,6 +20,7 @@ type applicationsFinder interface {
 		orgID iam.OrgID,
 		pagination PaginationParams,
 	) (Paginated[[]domain.Application], error)
+	FindByID(ctx context.Context, id domain.ApplicationID, orgID iam.OrgID) (*domain.Application, error)
 }
 
 type allApplicationsHandler struct {

--- a/internal/app/query/application.go
+++ b/internal/app/query/application.go
@@ -1,0 +1,24 @@
+package query
+
+import (
+	"context"
+
+	"github.com/subscribeddotdev/subscribed-backend/internal/domain"
+)
+
+type Application struct {
+	OrgID         string
+	ApplicationID string
+}
+
+type applicationHandler struct {
+	applicationsFinder applicationsFinder
+}
+
+func NewApplicationHandler(applicationsFinder applicationsFinder) applicationHandler {
+	return applicationHandler{applicationsFinder: applicationsFinder}
+}
+
+func (h applicationHandler) Execute(ctx context.Context, q Application) (*domain.Application, error) {
+	return nil, nil
+}

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -8,6 +8,7 @@ import (
 var (
 	ErrApiKeyExists        = errors.New("the api key already exists")
 	ErrApiKeyNotFound      = errors.New("api key not found")
+	ErrAppNotFound         = errors.New("application not found")
 	ErrEndpointNotFound    = errors.New("endpoint not found")
 	ErrEventTypeNotFound   = errors.New("event type not found")
 	ErrMessageNotFound     = errors.New("message not found")


### PR DESCRIPTION
- Add open api spec for `GET /applications/:id`;
- Added repo interface method to find applications via `id` and `orgId`;
- Although the `orgId` is not needed to complete such a query, I think that is adding it to the SQL query is good way to ensure that the data that the user gets is properly scoped by an `orgId`;